### PR TITLE
Fix karma version to ~0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "browser-sync": "~1.5.7",
     "chalk": "^0.4.0",
     "del": "~0.1.3",
+    "karma": "~0.12.0",
     "gulp": "^3.8.0",
     "gulp-autoprefixer": "^0.0.6",
     "gulp-browserify": "^0.5.1",


### PR DESCRIPTION
To resolve:

npm ERR! peerinvalid The package karma does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer gulp-karma@0.0.4 wants karma@>=0.10 <=0.13
npm ERR! peerinvalid Peer karma-jasmine@0.1.6 wants karma@>=0.9
npm ERR! peerinvalid Peer karma-phantomjs-launcher@0.1.4 wants karma@>=0.9