### PR TITLE
Make bower install non interactive

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   },
   "devDependencies": {},
   "scripts": {
-    "postinstall": "./node_modules/.bin/bower install && ./node_modules/.bin/gulp"
+    "postinstall": "./node_modules/.bin/bower install --config.interactive=false && ./node_modules/.bin/gulp"
   }
 }


### PR DESCRIPTION
When running bower install for the first time ( as in an ansible deploy ) it asks questions! Add config to silence it.