### PR TITLE
Add simulation output files

### DIFF
--- a/src/modules/cmb/core/tpls/cmb-project-panel.html
+++ b/src/modules/cmb/core/tpls/cmb-project-panel.html
@@ -131,6 +131,12 @@
                     <label>Log</label>
                     <pre>{{taskLog}}</pre>
                 </div>
+                <div ng-show="isFinished(simulation)">
+                    <label>Output</label>
+                    <div ng-repeat="file in taskOutput | filter: fileFilter()">
+                        <a ng-href="{{ apiBase }}file/{{file._id}}/download">{{file.name}}</a>
+                    </div>
+                </div>
             </md-content>
     </accordion>
 </md-content>


### PR DESCRIPTION
@TristanWright This fixes #37, its a little basic at the moment. Just provides a list of the output files that can be clicked on to download them. It would be nice to be able to view the files directly in the browser if possible. 