### PR TITLE
Force login, rather that init authToken from cookie

### DIFF
--- a/src/modules/girder/kw.girder.js
+++ b/src/modules/girder/kw.girder.js
@@ -9,7 +9,7 @@ angular.module("kitware.girder", ["ngCookies"])
         // Internal state
         var apiBasePathURL = '/api/v1/',
             user = null,
-            authToken = $cookies.girderToken,
+            authToken = null,
             taskList = {},
             collectionMap = {};
 


### PR DESCRIPTION
@TristanWright this fixes #96 However, I think we need to improve our authentication scheme as I am not sure we currently handle a token expiring or being invalidated on the server side.