### PR TITLE
Inline vtkweb-loader action to disable WebGL renderers

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,15 @@
     <title>HPC Cloud</title>
     <meta name="description" content="Leverage cloud resources to do parallel computation and visualization.">
     <meta name="viewport" content="width=device-width">
+
+    <link rel="stylesheet" href="assets/vtk-web/ext/fontello/css/animation.css">
+    <link rel="stylesheet" href="assets/vtk-web/ext/fontello/css/fontello.css">
+    <link rel="stylesheet" href="assets/vtk-web/ext/bootstrap3/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="assets/vtk-web/ext/bootstrap3/css/bootstrap.min.css">
+    <link rel="stylesheet" href="assets/vtk-web/lib/css/paraview.ui.proxy.editor.css">
+    <link rel="stylesheet" href="assets/vtk-web/lib/css/paraview.ui.opacity.editor.css">
+    <link rel="stylesheet" href="assets/vtk-web/lib/css/paraview.ui.color.editor.css">
+
     <link rel="stylesheet" href="css/vendors.css">
     <link rel="stylesheet" href="css/chpc-min.css">
   </head>
@@ -40,7 +49,21 @@
     <script src="js/chpc-tpl.js"></script>
     <script src="js/chpc-min.js"></script>
 
-    <script src="assets/vtk-web/lib/core/vtkweb-loader-min.js" load="core, pv-visualizer, pv-visualizer-main-js"></script>
+    <script type="text/javascript" src="assets/vtk-web/ext/core/jquery-1.8.3.min.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/ext/core/autobahn.min.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/ext/core/jquery.hammer.min.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/core/vtkweb-all.min.js"></script>
+
+    <script type="text/javascript" src="assets/vtk-web/ext/bootstrap3/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/js/paraview.ui.action.list.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/js/paraview.ui.files.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/js/paraview.ui.data.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/js/paraview.ui.proxy.editor.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/js/paraview.ui.svg.pipeline.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/js/paraview.ui.opacity.editor.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/lib/js/paraview.ui.color.editor.js"></script>
+    <script type="text/javascript" src="assets/vtk-web/apps/Visualizer/main.js"></script>
+
     <script type="text/javascript" src="assets/ng-pvw/PvwAngularComponents.js"></script>
   </body>
 </html>


### PR DESCRIPTION
One of the WebGL Renderer was creating too many WebGL context and
some browsers were complaining about it. For now, we have chosen to
disable the WebGL capabilities of ParaViewWeb all together by not
loading VGL and gl-matrix.