### PR TITLE
Ensure angular-aria is included by main-bower-files

### DIFF
--- a/gulp/vendor.js
+++ b/gulp/vendor.js
@@ -25,7 +25,14 @@ gulp.task('bower-css', function () {
 });
 
 gulp.task('bower-js', function () {
-  return gulp.src($.mainBowerFiles())
+  options = {
+    overrides: {
+      'angular-aria': {
+         main: '**/*.js'
+      }
+    }
+  }
+  return gulp.src($.mainBowerFiles(options))
     .pipe($.filter('**/*.js'))
     // .pipe($.debug({verbose: true}))
     // .pipe($.flatten())


### PR DESCRIPTION
The main-bower-files, seem be skipping angular-aria for some reason.
For now force it to be included using an override.