### PR TITLE
reduction in status/log calls

### DIFF
--- a/src/pages/Simulation/View/index.js
+++ b/src/pages/Simulation/View/index.js
@@ -3,6 +3,8 @@ import Workflows from '../../../workflows';
 import tools     from  '../../../tools';
 
 import { connect } from 'react-redux';
+import { dispatch } from '../../../redux';
+import * as Actions from '../../../redux/actions/taskflows';
 
 const SimulationView = React.createClass({
 
@@ -13,6 +15,7 @@ const SimulationView = React.createClass({
     params: React.PropTypes.object,
     simulation: React.PropTypes.object,
     project: React.PropTypes.object,
+    onMount: React.PropTypes.func,
   },
 
   getDefaultProps() {
@@ -20,6 +23,18 @@ const SimulationView = React.createClass({
       project: null,
       simulation: null,
     };
+  },
+
+  componentDidMount() {
+    if (this.props.simulation) {
+      this.props.onMount(this.props.simulation);
+    }
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.simulation && nextProps.simulation && Object.keys(nextProps.simulation.steps).length) {
+      this.props.onMount(nextProps.simulation);
+    }
   },
 
   render() {
@@ -65,6 +80,11 @@ export default connect(
     return {
       project,
       simulation,
+    };
+  },
+  () => {
+    return {
+      onMount: (simulation) => dispatch(Actions.updateTaskflowFromSimulation(simulation)),
     };
   }
 )(SimulationView);

--- a/src/redux/actions/projects.js
+++ b/src/redux/actions/projects.js
@@ -3,7 +3,7 @@ import * as netActions  from './network';
 import { dispatch }     from '../index.js';
 
 import * as router          from './router';
-import * as TaskflowActions from './taskflows';
+// import * as TaskflowActions from './taskflows';
 
 export const FETCH_PROJECT_LIST = 'FETCH_PROJECT_LIST';
 export const UPDATE_PROJECT_LIST = 'UPDATE_PROJECT_LIST';
@@ -36,9 +36,9 @@ export function fetchProjectSimulations(id) {
           dispatch(netActions.successNetworkCall(action.id, resp));
           dispatch(updateProjectSimulations(id, simulations));
 
-          simulations.forEach(simulation => {
-            dispatch(TaskflowActions.updateTaskflowFromSimulation(simulation));
-          });
+          // simulations.forEach(simulation => {
+          //   dispatch(TaskflowActions.updateTaskflowFromSimulation(simulation));
+          // });
         },
         error => {
           dispatch(netActions.errorNetworkCall(action.id, error));

--- a/src/redux/actions/taskflows.js
+++ b/src/redux/actions/taskflows.js
@@ -186,7 +186,7 @@ export function updateAllTaskflows() {
   return dispatch => {
     const state = store.getState();
     Object.keys(state.taskflows.mapById).forEach(id => {
-      if (state.taskflows.mapById[id].status !== 'complete') {
+      if (state.taskflows.mapById[id].status !== 'complete' && state.taskflows.mapById[id].status !== 'terminated') {
         dispatch(fetchTaskflow(id));
         dispatch(fetchTaskflowTasks(id));
       }
@@ -276,7 +276,7 @@ client.onEvent((resp) => {
         break;
       }
       case 'task': {
-        dispatch(fetchTaskflowTasks(taskflowId, id, status));
+        dispatch(updateTaskflowTaskStatus(taskflowId, id, status));
         break;
       }
       default:

--- a/src/workflows/pyfr/pyfr-simput/components/steps/Input/index.js
+++ b/src/workflows/pyfr/pyfr-simput/components/steps/Input/index.js
@@ -75,9 +75,11 @@ export default React.createClass({
     // Need to fill up the jsonData
     if (!jsonData) {
       const boundaryNames = {};
-      this.props.project.metadata.boundaries.forEach(name => {
-        boundaryNames[name] = name;
-      });
+      if (this.props.project.metadata.boundaries) {
+        this.props.project.metadata.boundaries.forEach(name => {
+          boundaryNames[name] = name;
+        });
+      }
 
       jsonData = {
         data: {},
@@ -149,7 +151,7 @@ export default React.createClass({
         console.log('no ini file');
       }
     } catch (e) {
-      console.log('Error when generating INI file', e);
+      console.error('Error when generating INI file', e);
     }
   },
 
@@ -165,8 +167,9 @@ export default React.createClass({
     const data = this.state.viewData,
       keypath = newData.id.split('.'),
       attrName = keypath.shift();
-
+    console.log(attrName, keypath, newData);
     data[attrName][keypath.join('.')].value = newData.value;
+    console.log(data, data[attrName][keypath.join('.')].value);
     this.setState({ viewData: data });
   },
 


### PR DESCRIPTION
- no longer fetch all simulation taskflows on first load.
- only fetch taskflow information when a simulation has been opened.

_

- still improvements to be made
  - should only fetch items from a folder if that folder has been opened
  - entirely get rid of [`updateAllTaskflows()`](https://github.com/Kitware/HPCCloud/blob/master/src/redux/actions/taskflows.js#L185), replace it with something smarter