### PR TITLE
network reductions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bootstrap": "3.3.6",
     "react-router": "2.0.1",
 
-    "paraviewweb": "1.5.3",
+    "paraviewweb": "1.5.4",
     "simput": "1.2.0",
     "pvw-visualizer": "1.0.11",
 

--- a/src/pages/Preferences/Cluster/index.js
+++ b/src/pages/Preferences/Cluster/index.js
@@ -52,6 +52,8 @@ const ClusterPrefs = React.createClass({
     onAddItem: React.PropTypes.func,
     onRemoveItem: React.PropTypes.func,
     onTestCluster: React.PropTypes.func,
+    fetchPresets: React.PropTypes.func,
+    fetchClusters: React.PropTypes.func,
   },
 
   getDefaultProps() {
@@ -66,6 +68,13 @@ const ClusterPrefs = React.createClass({
 
   getInitialState() {
     return { _error: null };
+  },
+
+  componentDidMount() {
+    if (!this.props.presetNames.length) {
+      this.props.fetchPresets();
+      this.props.fetchClusters();
+    }
   },
 
   changeItem(item) {
@@ -208,6 +217,8 @@ export default connect(
       onAddItem: () => dispatch(Actions.addCluster()),
       onRemoveItem: (index, cluster) => dispatch(Actions.removeCluster(index, cluster)),
       onTestCluster: (index, cluster) => dispatch(Actions.testCluster(index, cluster)),
+      fetchPresets: () => dispatch(Actions.fetchClusterPresets()),
+      fetchClusters: () => dispatch(Actions.fetchClusters('trad')),
     };
   }
 )(ClusterPrefs);

--- a/src/pages/Preferences/ServerStatus/index.js
+++ b/src/pages/Preferences/ServerStatus/index.js
@@ -30,6 +30,7 @@ const StatusPage = React.createClass({
 
     subscribeClusterLog: React.PropTypes.func,
     unsubscribeClusterLog: React.PropTypes.func,
+    fetchClusters: React.PropTypes.func,
   },
 
   getDefaultProps() {
@@ -37,6 +38,10 @@ const StatusPage = React.createClass({
       ec2: [],
       clusters: [],
     };
+  },
+
+  componentDidMount() {
+    this.props.fetchClusters();
   },
 
   componentWillUnmount() {
@@ -119,5 +124,6 @@ export default connect(
   () => ({
     subscribeClusterLog: (id, offset) => dispatch(ClusterActions.subscribeClusterLogStream(id, offset)),
     unsubscribeClusterLog: (id) => dispatch(ClusterActions.unsubscribeClusterLogStream(id)),
+    fetchClusters: () => dispatch(ClusterActions.fetchClusters()),
   })
 )(StatusPage);

--- a/src/pages/Simulation/View/index.js
+++ b/src/pages/Simulation/View/index.js
@@ -6,6 +6,7 @@ import LoadingPanel from '../../../panels/LoadingPanel';
 import { connect } from 'react-redux';
 import { dispatch } from '../../../redux';
 import * as Actions from '../../../redux/actions/taskflows';
+import { fetchClusters } from '../../../redux/actions/clusters';
 
 const SimulationView = React.createClass({
 
@@ -17,6 +18,7 @@ const SimulationView = React.createClass({
     simulation: React.PropTypes.object,
     project: React.PropTypes.object,
     onMount: React.PropTypes.func,
+    fetchClusters: React.PropTypes.func,
   },
 
   getDefaultProps() {
@@ -29,6 +31,7 @@ const SimulationView = React.createClass({
   componentDidMount() {
     if (this.props.simulation) {
       this.props.onMount(this.props.simulation);
+      this.props.fetchClusters();
     }
   },
 
@@ -86,6 +89,7 @@ export default connect(
   () => {
     return {
       onMount: (simulation) => dispatch(Actions.updateTaskflowFromSimulation(simulation)),
+      fetchClusters: () => dispatch(fetchClusters()),
     };
   }
 )(SimulationView);

--- a/src/redux/actions/aws.js
+++ b/src/redux/actions/aws.js
@@ -95,9 +95,7 @@ export function updateAWSProfile(index, profile, pushToServer = false) {
 
 // Auto trigger actions on authentication change...
 client.onAuthChange(authenticated => {
-  if (authenticated) {
-    dispatch(fetchAWSProfiles());
-  } else {
+  if (!authenticated) {
     dispatch(updateAWSProfiles([]));
   }
 });

--- a/src/redux/actions/clusters.js
+++ b/src/redux/actions/clusters.js
@@ -139,7 +139,7 @@ export function fetchCluster(id) {
   };
 }
 
-export function fetchClusters(type = 'trad') {
+export function fetchClusters(type) {
   return dispatch => {
     const action = netActions.addNetworkCall('fetch_clusters', 'Retreive clusters');
     dispatch(pendingNetworkCall(true));
@@ -267,11 +267,7 @@ export function terminateCluster(id) {
 
 // Auto trigger actions on authentication change...
 client.onAuthChange(authenticated => {
-  if (authenticated) {
-    dispatch(fetchClusters('trad'));
-    dispatch(fetchClusters('ec2'));
-    dispatch(fetchClusterPresets());
-  } else {
+  if (!authenticated) {
     dispatch(updateClusters([]));
   }
 });

--- a/src/redux/reducers/clusters.js
+++ b/src/redux/reducers/clusters.js
@@ -82,7 +82,6 @@ export default function clustersReducer(state = initialState, action) {
     case Actions.ADD_EXISTING_CLUSTER: {
       const newCluster = action.cluster;
       const mapById = Object.assign({}, state.mapById);
-      console.log('adding cluster', newCluster);
       mapById[newCluster._id] = newCluster;
       return Object.assign({}, state, { mapById });
     }
@@ -109,19 +108,16 @@ export default function clustersReducer(state = initialState, action) {
     }
 
     case Actions.UPDATE_CLUSTERS: {
-      const list = action.clusters;
+      // do not save ec2 clusters in the list, it's only used for trad clusters
+      const list = action.clusters.filter((cluster) => cluster.type === 'trad');
       const active = (state.active < list.length) ? state.active : (list.length - 1);
       const mapById = Object.assign({}, state.mapById);
       updateIcon(list);
-      list.forEach(cluster => {
+      action.clusters.forEach(cluster => {
         if (cluster._id) {
           mapById[cluster._id] = cluster;
         }
       });
-      // do not save ec2 clusters in the list, it's only used for trad clusters
-      if (list.length && list[0].type !== 'trad') {
-        return Object.assign({}, state, { mapById });
-      }
       return Object.assign({}, state, { list, active, mapById });
     }
 

--- a/src/workflows/pyfr/common/steps/Simulation/View/index.js
+++ b/src/workflows/pyfr/common/steps/Simulation/View/index.js
@@ -95,7 +95,6 @@ const SimualtionView = React.createClass({
     const { taskflow, taskflowId, simulation, buttonsDisabled, error } = this.props;
     const actions = [].concat(taskflow.actions ? taskflow.actions : []);
 
-    // Extract meaningful information from props
     if (taskflow.allComplete) {
       actions.push('visualize');
     }

--- a/src/workflows/visualizer/components/steps/Visualization/View/index.js
+++ b/src/workflows/visualizer/components/steps/Visualization/View/index.js
@@ -90,13 +90,14 @@ const visualizationView = React.createClass({
 
     const { taskflow, taskflowId, error, simulation } = this.props;
     const actions = [].concat(taskflow.actions);
-    const tasks = Object.keys(taskflow.taskMapById).map(id => taskflow.taskMapById[id]);
-    const jobs = Object.keys(taskflow.jobMapById).map(id => taskflow.jobMapById[id]);
+    const tasks = taskflow.taskMapById ? Object.keys(taskflow.taskMapById).map(id => taskflow.taskMapById[id]) : [];
+    const jobs = taskflow.jobMapById ? Object.keys(taskflow.jobMapById).map(id => taskflow.jobMapById[id]) : [];
 
     // Extract meaningful information from props
-    if (jobs.some(job => job.name === this.props.primaryJob && job.status === 'running')) {
+    if (jobs.length && jobs.some(job => job.name === this.props.primaryJob && job.status === 'running')) {
       actions.push('visualize');
-    } else if (jobs.every(job => job.status === 'complete') &&
+    } else if (jobs.length && tasks.length &&
+        jobs.every(job => job.status === 'complete') &&
         tasks.every(task => task.status === 'complete')) {
       actions.push('rerun');
     }


### PR DESCRIPTION
- only fetch clusters and aws profiles when those resources are used

We're still fetching all projects and their simulations on load. Couldn't find a good way to do it backwards today.