### PR TITLE
fix(Visualizer): Enable auto retry

### DIFF
--- a/src/tools/visualizer/index.js
+++ b/src/tools/visualizer/index.js
@@ -57,6 +57,7 @@ export default React.createClass({
       .then((resp) => {
         const config = {
           sessionURL: `ws://${location.hostname}:8888/proxy?sessionId=${resp.data.metadata.sessionId}&path=ws`,
+          retry: true,
         };
         network.connect(config);
       })


### PR DESCRIPTION
We want this behaviour so if the pvpython process is not ready the client will keep trying to connect.

This requires Kitware/paraviewweb#113 to be merged ( in order to have any effect ...).