### PR TITLE
Remove '_id' from expected and get rid of slice

### DIFF
--- a/src/network/remote/simulations.js
+++ b/src/network/remote/simulations.js
@@ -11,8 +11,8 @@ export default function ({ client, filterQuery, mustContain, busy }) {
     },
 
     editSimulation(simulation) {
-      const expected = ['name', 'description', 'active', 'disabled', 'metadata', 'steps', '_id'],
-        sfiltered = filterQuery(simulation, ...expected.slice(0, 5)); // Remove '_id'
+      const expected = ['name', 'description', 'active', 'disabled', 'metadata', 'steps'],
+        sfiltered = filterQuery(simulation, ...expected);
 
       return busy(client._.patch(`/simulations/${simulation._id}`, sfiltered, {
         headers, transformRequest,


### PR DESCRIPTION
Not sure why we init the array to contain '_id' and then remove it?
Anyway as 'steps' was added to the array the slice index was wrong
causing an issue. So I have removed '_id' from the array.