### PR TITLE
Network error handling

### DIFF
--- a/src/pages/Preferences/AWS/index.js
+++ b/src/pages/Preferences/AWS/index.js
@@ -5,11 +5,11 @@ import Toolbar          from '../../../panels/Toolbar';
 import React            from 'react';
 import EmptyPlaceholder from '../../../panels/EmptyPlaceholder';
 import { breadcrumb }   from '..';
+import getNetworkError  from '../../../utils/getNetworkError';
 
 import theme from 'HPCCloudStyle/Theme.mcss';
 import style from 'HPCCloudStyle/PageWithMenu.mcss';
 
-import get          from 'mout/src/object/get';
 import { connect }  from 'react-redux';
 import * as Actions from '../../../redux/actions/aws';
 import { dispatch } from '../../../redux';
@@ -159,11 +159,17 @@ const AWSPrefs = React.createClass({
 export default connect(
   state => {
     const localState = state.preferences.aws;
+    var error = getNetworkError(state, 'save_aws_profile');
+
+    if (!error) {
+      error = getNetworkError(state, 'remove_aws_profile');
+    }
+
     return {
       active: localState.active,
       list: localState.list,
       buttonsDisabled: localState.pending,
-      error: get(state, 'network.error.save_aws_profile.resp.data.message'),
+      error,
     };
   },
   () => {

--- a/src/pages/Project/Edit/index.js
+++ b/src/pages/Project/Edit/index.js
@@ -2,13 +2,12 @@ import ItemEditor   from '../../../panels/ItemEditor';
 import React        from 'react';
 
 import Workflows    from '../../../workflows';
+import getNetworkError  from '../../../utils/getNetworkError';
 
 import { connect }  from 'react-redux';
-import get          from 'mout/src/object/get';
 import { dispatch } from '../../../redux';
 import * as Router  from '../../../redux/actions/router';
 import * as Actions from '../../../redux/actions/projects';
-import * as NetActions from '../../../redux/actions/network';
 
 /* eslint-disable no-alert */
 const ProjectEdit = React.createClass({
@@ -24,12 +23,6 @@ const ProjectEdit = React.createClass({
     onDelete: React.PropTypes.func,
     onCancel: React.PropTypes.func,
     invalidateError: React.PropTypes.func,
-  },
-
-  componentWillUnmount() {
-    if (this.props.error) {
-      this.props.invalidateError(this.props.project._id);
-    }
   },
 
   onAction(action, data, attachement) {
@@ -82,15 +75,15 @@ const ProjectEdit = React.createClass({
 
 export default connect(
   (state, props) => {
-    var error;
-    if (!get(state, 'network.error.save_project.resp.data.invalid') &&
-      !get(state, `network.error.delete_project_${props.params.id}.resp.data.invalid`)) {
-      error = get(state, 'network.error.save_project.resp.data.message') || get(state, `network.error.delete_project_${props.params.id}.resp.data.message`);
+    var error = getNetworkError(state, 'save_project');
+
+    if (!error) {
+      error = getNetworkError(state, 'delete_project');
     }
 
     return {
-      error,
       project: state.projects.mapById[props.params.id],
+      error,
     };
   },
   () => {
@@ -98,7 +91,6 @@ export default connect(
       onSave: (project) => dispatch(Actions.saveProject(project)),
       onDelete: (project) => dispatch(Actions.deleteProject(project)),
       onCancel: (path) => dispatch(Router.goBack()),
-      invalidateError: (id) => dispatch(NetActions.invalidateError(id)),
     };
   }
 )(ProjectEdit);

--- a/src/pages/Project/New/index.js
+++ b/src/pages/Project/New/index.js
@@ -1,11 +1,11 @@
 import ItemEditor   from '../../../panels/ItemEditor';
 import React        from 'react';
 import Workflows    from '../../../workflows';
+import getNetworkError  from '../../../utils/getNetworkError';
 
 import style        from 'HPCCloudStyle/ItemEditor.mcss';
 
 import { connect }  from 'react-redux';
-import get          from 'mout/src/object/get';
 import { dispatch } from '../../../redux';
 import * as Actions from '../../../redux/actions/projects';
 import * as Router  from '../../../redux/actions/router';
@@ -27,6 +27,12 @@ const ProjectNew = React.createClass({
       _error: null,
       type: this.props.workflowNames[0].value,
     };
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState._error !== this.state._error) {
+      setTimeout(() => { this.setState({ _error: null }); }, 3000);
+    }
   },
 
   onAction(action, data, attachments) {
@@ -111,7 +117,7 @@ export default connect(
   state => {
     return {
       workflowNames: state.projects.workflowNames,
-      error: get(state, 'network.error.save_project.resp.data.message'),
+      error: getNetworkError(state, 'save_project'),
     };
   },
   () => {

--- a/src/pages/Project/New/index.js
+++ b/src/pages/Project/New/index.js
@@ -29,10 +29,18 @@ const ProjectNew = React.createClass({
     };
   },
 
+  componentDidMount() {
+    this.timeout = null;
+  },
+
   componentDidUpdate(prevProps, prevState) {
     if (prevState._error !== this.state._error) {
-      setTimeout(() => { this.setState({ _error: null }); }, 3000);
+      this.timeout = setTimeout(() => { this.setState({ _error: null }); }, 3000);
     }
+  },
+
+  componentWillUnmount() {
+    clearTimeout(this.timeout);
   },
 
   onAction(action, data, attachments) {

--- a/src/redux/actions/network.js
+++ b/src/redux/actions/network.js
@@ -24,12 +24,13 @@ export function successNetworkCall(id, resp) {
   return { type: SUCCESS_NETWORK_CALL, id, resp };
 }
 
-export function errorNetworkCall(id, resp) {
-  return { type: ERROR_NETWORK_CALL, id, resp };
-}
-
 export function invalidateError(id) {
   return { type: INVALIDATE_ERROR, id };
+}
+
+export function errorNetworkCall(id, resp) {
+  setTimeout(() => { dispatch(invalidateError(id)); }, 3000);
+  return { type: ERROR_NETWORK_CALL, id, resp };
 }
 
 export function prepareUpload(files) {

--- a/src/redux/actions/network.js
+++ b/src/redux/actions/network.js
@@ -5,6 +5,7 @@ export const ADD_NETWORK_CALL = 'ADD_NETWORK_CALL';
 export const SUCCESS_NETWORK_CALL = 'SUCCESS_NETWORK_CALL';
 export const ERROR_NETWORK_CALL = 'ERROR_NETWORK_CALL';
 export const INVALIDATE_ERROR = 'INVALIDATE_ERROR';
+export const INVALIDATE_ERRORS = 'INVALIDATE_ERRORS';
 export const PREPARE_UPLOAD = 'PREPARE_UPLOAD';
 export const RESET_PROGRESS = 'RESET_PROGRESS';
 export const ON_PROGRESS = 'ON_PROGRESS';
@@ -28,9 +29,14 @@ export function invalidateError(id) {
   return { type: INVALIDATE_ERROR, id };
 }
 
+// takes an array of ids which the reducer then invalidates all of
+export function invalidateErrors(ids) {
+  return { type: INVALIDATE_ERRORS, ids };
+}
+
 export function errorNetworkCall(id, resp) {
-  setTimeout(() => { dispatch(invalidateError(id)); }, 3000);
-  return { type: ERROR_NETWORK_CALL, id, resp };
+  var errorTimeout = setTimeout(() => { dispatch(invalidateError(id)); }, 3000);
+  return { type: ERROR_NETWORK_CALL, id, resp, errorTimeout };
 }
 
 export function prepareUpload(files) {

--- a/src/redux/actions/projects.js
+++ b/src/redux/actions/projects.js
@@ -68,7 +68,7 @@ export function fetchProjectList() {
 
 export function deleteProject(project) {
   return dispatch => {
-    const action = netActions.addNetworkCall(`delete_project_${project._id}`, `Delete project ${project.name}`);
+    const action = netActions.addNetworkCall('delete_project', `Delete project ${project.name}`);
 
     client.deleteProject(project._id)
       .then(

--- a/src/redux/reducers/network.js
+++ b/src/redux/reducers/network.js
@@ -38,7 +38,7 @@ export default function networkReducer(state = initialState, action) {
 
     case Actions.ERROR_NETWORK_CALL: {
       const pending = Object.assign({}, state.pending);
-      const callToMove = Object.assign({}, pending[action.id], { resp: action.resp });
+      const callToMove = Object.assign({}, pending[action.id], { resp: action.resp, invalid: false });
       const error = Object.assign({}, state.error, { [action.id]: callToMove });
       delete pending[action.id];
 
@@ -49,10 +49,8 @@ export default function networkReducer(state = initialState, action) {
       const id = action.id;
       const error = Object.assign({}, state.error);
 
-      if (error[`delete_project_${id}`].resp.data.message) {
-        error[`delete_project_${id}`].resp.data.invalid = true;
-      } else if (error.save_project.resp.data.message) {
-        error.save_project.resp.data.invalid = true;
+      if (error[id].resp.data.message) {
+        error[id].invalid = true;
       }
 
       return Object.assign({}, state, { error });

--- a/src/redux/reducers/network.js
+++ b/src/redux/reducers/network.js
@@ -5,6 +5,7 @@ const initialState = {
   success: {},
   error: {},
   backlog: [],
+  errorTimeout: null,
   progress: {},
   progressReset: false,
 };
@@ -42,7 +43,11 @@ export default function networkReducer(state = initialState, action) {
       const error = Object.assign({}, state.error, { [action.id]: callToMove });
       delete pending[action.id];
 
-      return Object.assign({}, state, { pending, error });
+      if (action.errorTimeout && state.errorTimeout !== null) {
+        clearTimeout(state.errorTimeout);
+      }
+
+      return Object.assign({}, state, { pending, error, errorTimeout: action.errorTimeout });
     }
 
     case Actions.INVALIDATE_ERROR: {
@@ -52,6 +57,19 @@ export default function networkReducer(state = initialState, action) {
       if (error[id].resp.data.message) {
         error[id].invalid = true;
       }
+
+      return Object.assign({}, state, { error, errorTimeout: null });
+    }
+
+    case Actions.INVALIDATE_ERRORS: {
+      const ids = action.ids;
+      const error = Object.assign({}, state.error);
+
+      ids.forEach((id) => {
+        if (error[id]) {
+          error[id].invalid = true;
+        }
+      });
 
       return Object.assign({}, state, { error });
     }

--- a/src/utils/getNetworkError.js
+++ b/src/utils/getNetworkError.js
@@ -1,0 +1,10 @@
+import get from './get';
+
+// checks the network errors, if there is a valid one it returns the error's message
+export default function getNetworkError(state, id) {
+  if (get(state, `network.error.${id}.resp.data.message`) &&
+    !get(state, `network.error.${id}.invalid`)) {
+    return get(state, `network.error.${id}.resp.data.message`);
+  }
+  return '';
+}


### PR DESCRIPTION
This addresses #433 and what I mentioned in the issue. 

When we make a client call and that call fails its response and a descriptive (non-unique) id get sent to the redux network store. Some components display errors based on those id's being in the network store. Those messages would never expire however, so the same error could persist across the same component in different contexts (e.g. the same error would carry over from deleting an aws profile to creating a new one). 

Those messages now expire after 3 seconds and components do not display old errors.