### PR TITLE
Cluster provision refactor

### DIFF
--- a/server/taskflows/hpccloud/taskflow/nwchem.py
+++ b/server/taskflows/hpccloud/taskflow/nwchem.py
@@ -72,30 +72,10 @@ class NWChemTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
     }
 
     def start(self, *args, **kwargs):
-        user = getCurrentUser()
-        # Load the cluster
-        # TODO: should this be in a common class?
-        cluster_id = parse('cluster._id').find(kwargs)
-        if cluster_id:
-            cluster_id = cluster_id[0].value
-            model = ModelImporter.model('cluster', 'cumulus')
-            cluster = model.load(cluster_id, user=user, level=AccessType.ADMIN)
-            cluster = model.filter(cluster, user, passphrase=False)
-            kwargs['cluster'] = cluster
-
-        profile_id = parse('cluster.profileId').find(kwargs)
-        if profile_id:
-            profile_id = profile_id[0].value
-            model = ModelImporter.model('aws', 'cumulus')
-            profile = model.load(profile_id, user=user, level=AccessType.ADMIN)
-            kwargs['profile'] = profile
-
         kwargs['image_spec'] = self.NWCHEM_IMAGE
         kwargs['next'] = setup_input.s()
 
-        super(NWChemTaskFlow, self).start(
-            setup_cluster.s(
-                self, *args, **kwargs))
+        super(NWChemTaskFlow, self).start(self, *args, **kwargs)
 
     def terminate(self):
         self.run_task(nwchem_terminate.s())

--- a/server/taskflows/hpccloud/taskflow/nwchem.py
+++ b/server/taskflows/hpccloud/taskflow/nwchem.py
@@ -20,8 +20,8 @@ import json
 import os
 from jsonpath_rw import parse
 
-import cumulus.taskflow.core
-from cumulus.taskflow.core import create_girder_client
+import cumulus.taskflow.cluster
+from cumulus.taskflow.cluster import create_girder_client
 from cumulus.tasks.job import submit_job, monitor_job
 from cumulus.tasks.job import download_job_input_folders
 from cumulus.tasks.job import upload_job_output_to_folder, job_directory
@@ -29,7 +29,7 @@ from cumulus.transport import get_connection
 
 from hpccloud.taskflow.utility import *
 
-class NWChemTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
+class NWChemTaskFlow(cumulus.taskflow.cluster.ClusterProvisioningTaskFlow):
     """
     {
         "input": {

--- a/server/taskflows/hpccloud/taskflow/nwchem.py
+++ b/server/taskflows/hpccloud/taskflow/nwchem.py
@@ -26,6 +26,7 @@ from jsonpath_rw import parse
 from bson.objectid import ObjectId
 
 import cumulus.taskflow.core
+from cumulus.taskflow.core import create_girder_client
 from cumulus.tasks.job import download_job_input_folders, submit_job
 from cumulus.tasks.job import monitor_job, monitor_jobs
 from cumulus.tasks.job import upload_job_output_to_folder

--- a/server/taskflows/hpccloud/taskflow/nwchem.py
+++ b/server/taskflows/hpccloud/taskflow/nwchem.py
@@ -25,7 +25,7 @@ from ConfigParser import SafeConfigParser
 from jsonpath_rw import parse
 from bson.objectid import ObjectId
 
-import cumulus.taskflow
+import cumulus.taskflow.core
 from cumulus.tasks.job import download_job_input_folders, submit_job
 from cumulus.tasks.job import monitor_job, monitor_jobs
 from cumulus.tasks.job import upload_job_output_to_folder
@@ -40,7 +40,7 @@ from girder_client import GirderClient, HttpError
 
 from hpccloud.taskflow.utility import *
 
-class NWChemTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
+class NWChemTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
     """
     {
         "input": {

--- a/server/taskflows/hpccloud/taskflow/nwchem.py
+++ b/server/taskflows/hpccloud/taskflow/nwchem.py
@@ -16,28 +16,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
-import tempfile
 import json
 import os
-import subprocess
-import shutil
-from ConfigParser import SafeConfigParser
 from jsonpath_rw import parse
-from bson.objectid import ObjectId
 
 import cumulus.taskflow.core
 from cumulus.taskflow.core import create_girder_client
-from cumulus.tasks.job import download_job_input_folders, submit_job
-from cumulus.tasks.job import monitor_job, monitor_jobs
-from cumulus.tasks.job import upload_job_output_to_folder
-from cumulus.tasks.job import terminate_job
-from cumulus.tasks.job import job_directory
+from cumulus.tasks.job import submit_job, monitor_job
+from cumulus.tasks.job import download_job_input_folders
+from cumulus.tasks.job import upload_job_output_to_folder, job_directory
 from cumulus.transport import get_connection
-from cumulus.transport.files.download import download_path_from_cluster
-from girder.utility.model_importer import ModelImporter
-from girder.api.rest import getCurrentUser
-from girder.constants import AccessType
-from girder_client import GirderClient, HttpError
+
+from girder_client import HttpError
 
 from hpccloud.taskflow.utility import *
 

--- a/server/taskflows/hpccloud/taskflow/nwchem.py
+++ b/server/taskflows/hpccloud/taskflow/nwchem.py
@@ -40,7 +40,7 @@ from girder_client import GirderClient, HttpError
 
 from hpccloud.taskflow.utility import *
 
-class NWChemTaskFlow(cumulus.taskflow.TaskFlow):
+class NWChemTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
     """
     {
         "input": {

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -34,7 +34,7 @@ from girder_client import GirderClient, HttpError
 
 from hpccloud.taskflow.utility import *
 
-class ParaViewTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
+class ParaViewTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
     """
     {
         "dataDir": <passed to --data-dir,

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -22,16 +22,12 @@ from jsonpath_rw import parse
 
 import cumulus.taskflow.core
 from cumulus.taskflow.core import create_girder_client
-from cumulus.tasks.job import download_job_input_folders, submit_job
-from cumulus.tasks.job import monitor_job, upload_job_output_to_folder
-from cumulus.tasks.job import job_directory
+from cumulus.tasks.job import submit_job, monitor_job
+from cumulus.tasks.job import upload_job_output_to_folder, job_directory
 from cumulus.transport import get_connection
 from cumulus.transport.files.upload import upload_file
 
-from girder.utility.model_importer import ModelImporter
-from girder.api.rest import getCurrentUser
-from girder.constants import AccessType
-from girder_client import GirderClient, HttpError
+from girder_client import HttpError
 
 from hpccloud.taskflow.utility import *
 

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -34,7 +34,7 @@ from girder_client import GirderClient, HttpError
 
 from hpccloud.taskflow.utility import *
 
-class ParaViewTaskFlow(cumulus.taskflow.TaskFlow):
+class ParaViewTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
     """
     {
         "dataDir": <passed to --data-dir,

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -20,7 +20,8 @@ import json
 import os
 from jsonpath_rw import parse
 
-import cumulus.taskflow
+import cumulus.taskflow.core
+from cumulus.taskflow.core import create_girder_client
 from cumulus.tasks.job import download_job_input_folders, submit_job
 from cumulus.tasks.job import monitor_job, upload_job_output_to_folder
 from cumulus.tasks.job import job_directory

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -55,28 +55,10 @@ class ParaViewTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
     }
 
     def start(self, *args, **kwargs):
-        user = getCurrentUser()
-        # Load the cluster
-        cluster_id = parse('cluster._id').find(kwargs)
-        if cluster_id:
-            model = ModelImporter.model('cluster', 'cumulus')
-            cluster = model.load(kwargs['cluster']['_id'],
-                                 user=user, level=AccessType.ADMIN)
-            cluster = model.filter(cluster, user, passphrase=False)
-            kwargs['cluster'] = cluster
-
-        profile_id = parse('cluster.profileId').find(kwargs)
-        if profile_id:
-            profile_id = profile_id[0].value
-            model = ModelImporter.model('aws', 'cumulus')
-            profile = model.load(profile_id, user=user, level=AccessType.ADMIN)
-            kwargs['profile'] = profile
-
         kwargs['next'] = create_paraview_job.s()
         kwargs['image_spec'] = self.PARAVIEW_IMAGE
 
-        super(ParaViewTaskFlow, self).start(
-            setup_cluster.s(self, *args, **kwargs))
+        super(ParaViewTaskFlow, self).start(self, *args, **kwargs)
 
     def terminate(self):
         self.run_task(paraview_terminate.s())

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -60,7 +60,6 @@ class ParaViewTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
                 image_spec['tags']['nvida_display_driver'] = '367.35'
             else:
                 image_spec['tags']['mesa'] = '8.0'
-            kwargs['image_spec'] = image_spec
 
         kwargs['image_spec'] = image_spec
         kwargs['next'] = create_paraview_job.s()

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -27,8 +27,6 @@ from cumulus.tasks.job import upload_job_output_to_folder, job_directory
 from cumulus.transport import get_connection
 from cumulus.transport.files.upload import upload_file
 
-from girder_client import HttpError
-
 from hpccloud.taskflow.utility import *
 
 class ParaViewTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
@@ -58,22 +56,11 @@ class ParaViewTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
         super(ParaViewTaskFlow, self).start(self, *args, **kwargs)
 
     def terminate(self):
-        self.run_task(paraview_terminate.s())
+        super(ParaViewTaskFlow, self).terminate()
         self.run_task(cleanup_proxy_entries.s())
 
     def delete(self):
-        client = create_girder_client(
-            self.girder_api_url, self.girder_token)
-        for job in self.get('meta', {}).get('jobs', []):
-            job_id = job['_id']
-            client.delete('jobs/%s' % job_id)
-
-            try:
-                client.get('jobs/%s' % job_id)
-            except HttpError as e:
-                if e.status != 404:
-                    self.logger.error('Unable to delete job: %s' % job_id)
-
+        super(ParaViewTaskFlow, self).delete()
         self.run_task(cleanup_proxy_entries.s())
 
 def validate_args(kwargs):

--- a/server/taskflows/hpccloud/taskflow/paraview.py
+++ b/server/taskflows/hpccloud/taskflow/paraview.py
@@ -20,8 +20,8 @@ import json
 import os
 from jsonpath_rw import parse
 
-import cumulus.taskflow.core
-from cumulus.taskflow.core import create_girder_client
+import cumulus.taskflow.cluster
+from cumulus.taskflow.cluster import create_girder_client
 from cumulus.tasks.job import submit_job, monitor_job
 from cumulus.tasks.job import upload_job_output_to_folder, job_directory
 from cumulus.transport import get_connection
@@ -29,7 +29,7 @@ from cumulus.transport.files.upload import upload_file
 
 from hpccloud.taskflow.utility import *
 
-class ParaViewTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
+class ParaViewTaskFlow(cumulus.taskflow.cluster.ClusterProvisioningTaskFlow):
     """
     {
         "dataDir": <passed to --data-dir,

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -78,29 +78,10 @@ class PyFrTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
     }
 
     def start(self, *args, **kwargs):
-        user = getCurrentUser()
-        # Load the cluster
-        cluster_id = parse('cluster._id').find(kwargs)
-        if cluster_id:
-            cluster_id = cluster_id[0].value
-            model = ModelImporter.model('cluster', 'cumulus')
-            cluster = model.load(cluster_id, user=user, level=AccessType.ADMIN)
-            cluster = model.filter(cluster, user, passphrase=False)
-            kwargs['cluster'] = cluster
-
-        profile_id = parse('cluster.profileId').find(kwargs)
-        if profile_id:
-            profile_id = profile_id[0].value
-            model = ModelImporter.model('aws', 'cumulus')
-            profile = model.load(profile_id, user=user, level=AccessType.ADMIN)
-            kwargs['profile'] = profile
-
         kwargs['image_spec'] = self.PYFR_IMAGE
         kwargs['next'] = setup_input.s()
 
-        super(PyFrTaskFlow, self).start(
-            setup_cluster.s(
-                self, *args, **kwargs))
+        super(PyFrTaskFlow, self).start(self, *args, **kwargs)
 
     def terminate(self):
         self.run_task(pyfr_terminate.s())

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -31,8 +31,6 @@ from cumulus.tasks.job import download_job_input_folders
 from cumulus.tasks.job import upload_job_output_to_folder
 from cumulus.transport.files.download import download_path_from_cluster
 
-from girder_client import HttpError
-
 from hpccloud.taskflow.utility import *
 
 BACKEND_SECTIONS = [
@@ -79,22 +77,6 @@ class PyFrTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
         kwargs['next'] = setup_input.s()
 
         super(PyFrTaskFlow, self).start(self, *args, **kwargs)
-
-    def terminate(self):
-        self.run_task(pyfr_terminate.s())
-
-    def delete(self):
-        for job in self.get('meta', {}).get('jobs', []):
-            job_id = job['_id']
-            client = create_girder_client(
-            self.girder_api_url, self.girder_token)
-            client.delete('jobs/%s' % job_id)
-
-            try:
-                client.get('jobs/%s' % job_id)
-            except HttpError as e:
-                if e.status != 404:
-                    self.logger.error('Unable to delete job: %s' % job_id)
 
 def _import_mesh(logger, input_path, output_path, extn):
     #

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -23,19 +23,15 @@ import subprocess
 import shutil
 from ConfigParser import SafeConfigParser
 from jsonpath_rw import parse
-from bson.objectid import ObjectId
 
 import cumulus.taskflow.core
 from cumulus.taskflow.core import create_girder_client
-from cumulus.tasks.job import download_job_input_folders, submit_job
-from cumulus.tasks.job import monitor_job, monitor_jobs
+from cumulus.tasks.job import submit_job, monitor_job, monitor_jobs
+from cumulus.tasks.job import download_job_input_folders
 from cumulus.tasks.job import upload_job_output_to_folder
-from cumulus.tasks.job import terminate_job
 from cumulus.transport.files.download import download_path_from_cluster
-from girder.utility.model_importer import ModelImporter
-from girder.api.rest import getCurrentUser
-from girder.constants import AccessType
-from girder_client import GirderClient, HttpError
+
+from girder_client import HttpError
 
 from hpccloud.taskflow.utility import *
 

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -25,7 +25,8 @@ from ConfigParser import SafeConfigParser
 from jsonpath_rw import parse
 from bson.objectid import ObjectId
 
-import cumulus.taskflow
+import cumulus.taskflow.core
+from cumulus.taskflow.core import create_girder_client
 from cumulus.tasks.job import download_job_input_folders, submit_job
 from cumulus.tasks.job import monitor_job, monitor_jobs
 from cumulus.tasks.job import upload_job_output_to_folder

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -24,8 +24,8 @@ import shutil
 from ConfigParser import SafeConfigParser
 from jsonpath_rw import parse
 
-import cumulus.taskflow.core
-from cumulus.taskflow.core import create_girder_client
+import cumulus.taskflow.cluster
+from cumulus.taskflow.cluster import create_girder_client
 from cumulus.tasks.job import submit_job, monitor_job, monitor_jobs
 from cumulus.tasks.job import download_job_input_folders
 from cumulus.tasks.job import upload_job_output_to_folder
@@ -40,7 +40,7 @@ BACKEND_SECTIONS = [
 ]
 PYFR_MESH_EXT = 'pyfrm'
 
-class PyFrTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
+class PyFrTaskFlow(cumulus.taskflow.cluster.ClusterProvisioningTaskFlow):
     """
     {
         "input": {

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -45,7 +45,7 @@ BACKEND_SECTIONS = [
 ]
 PYFR_MESH_EXT = 'pyfrm'
 
-class PyFrTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
+class PyFrTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
     """
     {
         "input": {

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -45,7 +45,7 @@ BACKEND_SECTIONS = [
 ]
 PYFR_MESH_EXT = 'pyfrm'
 
-class PyFrTaskFlow(cumulus.taskflow.TaskFlow):
+class PyFrTaskFlow(cumulus.taskflow.ClusterProvisioningTaskFlow):
     """
     {
         "input": {

--- a/server/taskflows/hpccloud/taskflow/pyfr.py
+++ b/server/taskflows/hpccloud/taskflow/pyfr.py
@@ -85,8 +85,7 @@ class PyFrTaskFlow(cumulus.taskflow.core.ClusterProvisioningTaskFlow):
             else:
                 image_spec['tags']['blas'] = '3.0'
 
-            kwargs['image_spec'] = image_spec
-
+        kwargs['image_spec'] = image_spec
         kwargs['next'] = setup_input.s()
 
         super(PyFrTaskFlow, self).start(self, *args, **kwargs)

--- a/server/taskflows/hpccloud/taskflow/utility/__init__.py
+++ b/server/taskflows/hpccloud/taskflow/utility/__init__.py
@@ -134,16 +134,3 @@ def create_ec2_cluster(task, cluster, profile, ami):
 
     return cluster
 
-def _get_image(logger, profile, image_spec):
-    # Fetch the image from the CloudProvider
-    provider = CloudProvider(profile)
-    images = provider.get_machine_images(name=image_spec['name'],
-                                         owner=image_spec['owner'])
-
-    if len(images) == 0:
-        raise Exception('Unable to locate machine image: %s' % image_spec['name'])
-    elif len(images) > 1:
-        logger.warn('Found more than one machine image for: %s' % image_spec['name'])
-
-    return images[0]['image_id']
-

--- a/server/taskflows/hpccloud/taskflow/utility/__init__.py
+++ b/server/taskflows/hpccloud/taskflow/utility/__init__.py
@@ -2,26 +2,6 @@ import json
 from jsonpath_rw import parse
 
 import cumulus
-from cumulus.tasks.job import terminate_job
-from cumulus.constants import JobState
-from cumulus.ansible.tasks.providers import CloudProvider
-
-def terminate_jobs(task, client, cluster, jobs):
-    for job in jobs:
-        task.logger.info('Terminating job %s' % job['_id'])
-        # Fetch the latest job info
-        job_url = 'jobs/%s' % job['_id']
-        job = client.get(job_url)
-
-        # Update the status to terminating
-        body = {
-            'status': JobState.TERMINATING
-        }
-        client.patch(job_url, data=json.dumps(body))
-
-        terminate_job(
-            cluster, job, log_write_url=None,
-            girder_token=task.taskflow.girder_token)
 
 def get_cluster_job_output_dir(cluster):
     job_output_dir \

--- a/server/taskflows/hpccloud/taskflow/utility/__init__.py
+++ b/server/taskflows/hpccloud/taskflow/utility/__init__.py
@@ -1,6 +1,5 @@
 import json
 from jsonpath_rw import parse
-from celery.canvas import Signature
 import requests
 
 import cumulus
@@ -44,93 +43,4 @@ def create_girder_client(girder_api_url, girder_token):
     client.token = girder_token
 
     return client
-
-def create_ec2_cluster(task, cluster, profile, ami):
-    machine_type = cluster['machine']['id']
-    nodeCount = cluster['clusterSize']-1
-    launch_spec = 'ec2'
-
-    # Look up the external IP of the deployment to user for firewall rules
-    r = requests.get(CHECKIP_URL)
-    r.raise_for_status()
-    source_ip = '%s/32' % r.text.strip()
-
-    extra_rules = [{
-        'proto': 'tcp',
-        'from_port': 9000,
-        'to_port': 9000,
-        'cidr_ip': source_ip
-    }]
-
-
-    task.logger.info('Using source ip: %s' % source_ip)
-
-    launch_params = {
-        'master_instance_type': machine_type,
-        'master_instance_ami': ami,
-        'node_instance_count': nodeCount,
-        'node_instance_type': machine_type,
-        'node_instance_ami': ami,
-        'gpu': cluster['machine']['gpu'],
-        'source_cidr_ip': source_ip,
-        'extra_rules': extra_rules
-    }
-    provision_spec = 'gridengine/site'
-    provision_params = {
-        'ansible_ssh_user': 'ubuntu'
-    }
-
-    body = {
-        'type': 'ec2',
-        'name': cluster['name'],
-         'config': {
-            'launch': {
-                'spec': launch_spec,
-                'params': launch_params
-            },
-            'provision': {
-                'spec': provision_spec
-            }
-        },
-        'profileId': cluster['profileId']
-    }
-    client = create_girder_client(
-        task.taskflow.girder_api_url, task.taskflow.girder_token)
-
-    try:
-        cluster = client.post('clusters',  data=json.dumps(body))
-    except HttpError as he:
-        task.logger.exception(he.responseText)
-        raise
-
-    msg = 'Created cluster: %s' % cluster['_id']
-    task.taskflow.logger.info(msg)
-    task.logger.info(msg)
-
-    # Now save cluster id in metadata
-    task.taskflow.set_metadata('cluster', cluster)
-
-    task.logger.info('Starting cluster.')
-
-    body = {
-        'status': 'launching'
-    }
-    client.patch('clusters/%s' % cluster['_id'], data=json.dumps(body))
-
-    secret_key = profile['secretAccessKey']
-    profile = profile.copy()
-    del profile['secretAccessKey']
-    log_write_url = '%s/clusters/%s/log' % (task.taskflow.girder_api_url,
-                                            cluster['_id'])
-    provision_params['cluster_state'] = 'running'
-    launch_params['cluster_state'] = 'running'
-    girder_token = task.taskflow.girder_token
-    cumulus.ansible.tasks.cluster.start_cluster(
-        launch_spec, provision_spec, cluster, profile, secret_key,
-        launch_params, provision_params, girder_token, log_write_url)
-
-    # Get the update to date cluster
-    cluster = client.get('clusters/%s' % cluster['_id'])
-
-    return cluster
 

--- a/server/taskflows/hpccloud/taskflow/utility/__init__.py
+++ b/server/taskflows/hpccloud/taskflow/utility/__init__.py
@@ -147,23 +147,3 @@ def _get_image(logger, profile, image_spec):
 
     return images[0]['image_id']
 
-@cumulus.taskflow.task
-def setup_cluster(task, *args,**kwargs):
-    cluster = kwargs['cluster']
-
-    if '_id' in cluster:
-        task.taskflow.logger.info('We are using an existing cluster: %s' % cluster['name'])
-    else:
-        task.taskflow.logger.info('We are creating an EC2 cluster.')
-        task.logger.info('Cluster name %s' % cluster['name'])
-        kwargs['machine'] = cluster.get('machine')
-        profile = kwargs.get('profile')
-        ami = _get_image(task.logger, profile, kwargs['image_spec'])
-        cluster = create_ec2_cluster(task, cluster, profile, ami)
-        task.logger.info('Cluster started.')
-
-    # Call any follow on task
-    if 'next' in kwargs:
-        kwargs['cluster'] = cluster
-        next = Signature.from_dict(kwargs['next'])
-        next.delay(*args, **kwargs)

--- a/server/taskflows/hpccloud/taskflow/utility/__init__.py
+++ b/server/taskflows/hpccloud/taskflow/utility/__init__.py
@@ -1,15 +1,10 @@
 import json
 from jsonpath_rw import parse
-import requests
 
 import cumulus
 from cumulus.tasks.job import terminate_job
 from cumulus.constants import JobState
 from cumulus.ansible.tasks.providers import CloudProvider
-
-from girder_client import GirderClient, HttpError
-
-CHECKIP_URL = 'http://checkip.amazonaws.com/'
 
 def terminate_jobs(task, client, cluster, jobs):
     for job in jobs:
@@ -37,10 +32,3 @@ def get_cluster_job_output_dir(cluster):
         job_output_dir = None
 
     return job_output_dir
-
-def create_girder_client(girder_api_url, girder_token):
-    client = GirderClient(apiUrl=girder_api_url)
-    client.token = girder_token
-
-    return client
-


### PR DESCRIPTION
This refactor moves much of the redundant code in the various taskflows to a new intermediate class, ClusterProvisioningTaskFlow, in cumulus. This PR depends on Kitware/cumulus#268.