### PR TITLE
Run form fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,10 +75,7 @@
     "test": "NODE_ENV='test' karma start test/karma.all.js",
     "test:redux": "NODE_ENV='test' karma start test/karma.redux.js",
     "test:component": "NODE_ENV='test' karma start test/karma.component.js",
-    "codecov": "cat coverage/lcov/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js",
-
-    "commit"            : "git cz",
-    "semantic-release"  : "semantic-release pre && npm publish && semantic-release post"
+    "codecov": "cat coverage/lcov/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js"
   },
   "bin": {
     "HPCCloud": "./bin/hpc-cloud-cli.js"

--- a/src/pages/Simulation/View/index.js
+++ b/src/pages/Simulation/View/index.js
@@ -36,6 +36,7 @@ const SimulationView = React.createClass({
   componentDidMount() {
     if (this.props.simulation) {
       this.props.onMount(this.props.simulation);
+      this.props.fetchClusters();
     }
   },
 

--- a/src/panels/run/RunEC2.js
+++ b/src/panels/run/RunEC2.js
@@ -6,7 +6,7 @@ import theme    from 'HPCCloudStyle/Theme.mcss';
 import style    from 'HPCCloudStyle/ItemEditor.mcss';
 
 export default React.createClass({
-  displayName: 'run/cluster',
+  displayName: 'panels/run/RunEC2',
 
   propTypes: {
     contents: React.PropTypes.object,

--- a/src/utils/getDisabledButtons.js
+++ b/src/utils/getDisabledButtons.js
@@ -39,6 +39,5 @@ export function getDisabledButtons(network, taskflow = {}) {
     }
   });
 
-  console.log(actions, taskflowId, clusterId, actions);
   return disabledButtons;
 }

--- a/src/workflows/pyfr/common/panels/RuntimeBackend/index.js
+++ b/src/workflows/pyfr/common/panels/RuntimeBackend/index.js
@@ -1,5 +1,6 @@
 import React      from 'react';
 import deepEquals from 'mout/src/lang/deepEquals';
+import get        from '../../../../..//utils/get';
 import formStyle  from 'HPCCloudStyle/ItemEditor.mcss';
 
 const TYPES = {
@@ -46,12 +47,12 @@ export default React.createClass({
         type = 'cuda';
         types.push(type);
       }
-      if (props.profiles.opencl && props.profiles.opencl.length) {
+      if (get(props, 'profiles.opencl.length')) {
         type = 'opencl';
         types.push(type);
         profile = props.profiles.opencl[0].name;
       }
-      if (props.profiles.openmp && props.profiles.openmp.length) {
+      if (get(props, 'profiles.openmp.length')) {
         type = 'openmp';
         types.push(type);
         profile = props.profiles.openmp[0].name;
@@ -110,9 +111,11 @@ export default React.createClass({
       return null;
     }
 
-    const profiles =
-      this.props.profiles && this.props.profiles[this.state.type] && Array.isArray(this.props.profiles[this.state.type])
-      ? this.props.profiles[this.state.type] : [];
+    let profiles = [];
+    if (get(this.props, `profiles.${this.state.type}`) && Array.isArray(this.props.profiles[this.state.type])) {
+      profiles = this.props.profiles[this.state.type];
+    }
+
     return (
       <div>
           <section className={formStyle.group}>

--- a/src/workflows/pyfr/common/steps/Simulation/Start/index.js
+++ b/src/workflows/pyfr/common/steps/Simulation/Start/index.js
@@ -6,8 +6,9 @@ import ClusterPayloads         from '../../../../../../utils/ClusterPayload';
 import RuntimeBackend          from '../../../panels/RuntimeBackend';
 
 import merge                   from 'mout/src/object/merge';
-
+import get              from '../../../../../../utils/get';
 import getNetworkError  from '../../../../../../utils/getNetworkError';
+
 import { connect } from 'react-redux';
 import { dispatch } from '../../../../../../redux';
 import * as Actions    from '../../../../../../redux/actions/taskflows';
@@ -148,7 +149,7 @@ const SimulationStart = React.createClass({
       backendProfiles = { cuda: false, openmp: [], opencl: [] };
     if (this.state.serverType === 'Traditional') {
       const clusterId = this.state.Traditional.profile;
-      if (this.props.clusters[clusterId] && this.props.clusters[clusterId].config && this.props.clusters[clusterId].config.pyfr) {
+      if (get(this.props, `clusters.${clusterId}.config.pyfr`)) {
         backendProfiles = this.props.clusters[clusterId].config.pyfr;
       }
     }


### PR DESCRIPTION
first two commits: some clean up to make some conditionals easier to read. 

last commit: fixes an issue with the backend being blank. Although we were [calling the endpoint, we weren't syncing the results in redux](https://github.com/Kitware/HPCCloud/blob/master/src/panels/run/RunCluster.js#L48-L68), so the backend wouldn't show up in the form. I only observed the issue directly after a `vagrant provision`. The fix is one line and we just make sure we fetch the clusters when the simulation page mounts.

We [also manually fetch the EC2](https://github.com/Kitware/HPCCloud/blob/master/src/panels/run/RunEC2.js#L45-L83) info and don't store it in redux this way.  So on the Run panels we're mixing redux and component states, which could be why so many form issues have come from these panels. Filing as an issue separately. 