### PR TITLE
remove presets when user logs out

### DIFF
--- a/src/redux/actions/clusters.js
+++ b/src/redux/actions/clusters.js
@@ -283,5 +283,6 @@ export function terminateCluster(id) {
 client.onAuthChange(authenticated => {
   if (!authenticated) {
     dispatch(updateClusters([]));
+    dispatch(updateClusterPresets({}));
   }
 });

--- a/src/redux/reducers/clusters.js
+++ b/src/redux/reducers/clusters.js
@@ -7,6 +7,7 @@ export const initialState = {
   list: [],
   active: 0,
   pending: false,
+  presets: {},
   mapById: {},
 };
 


### PR DESCRIPTION
issue: 

- log in, 
- go to cluster page
- log out.
- log in 
- go to cluster page, no clusters will load. 

This fixes that, we only pull clusters if there are also no presets, which we do not clear when the user logs out.