### PR TITLE
error catching for tf deletion, added missing metadata property

### DIFF
--- a/src/redux/actions/projects.js
+++ b/src/redux/actions/projects.js
@@ -224,7 +224,7 @@ export function updateSimulationStep(id, stepName, data, location) {
     const state = store.getState().simulations.mapById[id];
     const stateTaskflowId = get(state, `steps.${stepName}.metadata.taskflowId`);
 
-    if (stateTaskflowId && stateTaskflowId !== data.metadata.taskflowId) {
+    if (stateTaskflowId && stateTaskflowId !== get(data, 'metadata.taskflowId')) {
       dispatch(taskflowActions.deleteTaskflow(stateTaskflowId));
     }
 

--- a/src/redux/reducers/simulations.js
+++ b/src/redux/reducers/simulations.js
@@ -13,7 +13,8 @@ export default function simulationsReducer(state = simInitialState, action) {
     }
 
     case Actions.UPDATE_SIMULATION: {
-      const mapById = Object.assign({}, state.mapById, { [action.simulation._id]: action.simulation });
+      const mapById = Object.assign({}, state.mapById);
+      mapById[action.simulation._id] = action.simulation;
       return Object.assign({}, state, { mapById });
     }
 

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -8,7 +8,7 @@ export const baseURL = '/api/v1';
 export const taskflowActions = {
   terminate: { name: 'terminateTaskflow', label: 'Terminate', icon: '' },
   visualize: { name: 'visualizeTaskflow', label: 'Visualize', icon: '' },
-  rerun: { name: 'deleteTaskflow', label: 'Rerun', icon: '' },
+  rerun: { name: 'rerun', label: 'Rerun', icon: '' },
   terminateInstance: { name: 'terminateInstance', label: 'Terminate EC2 Instance', icon: '' },
 };
 

--- a/src/widgets/Toaster/index.js
+++ b/src/widgets/Toaster/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import get   from '../../utils/get';
 import style from 'HPCCloudStyle/Toaster.mcss';
 
 import { connect }  from 'react-redux';
@@ -44,9 +44,9 @@ export default connect(
     let message = '';
     if (localState.activeErrors.application.length) {
       id = localState.activeErrors.application[0];
-      if (localState.error[id].resp.data) {
+      if (get(localState, `error.${id}.resp.data`)) {
         message = localState.error[id].resp.data.message;
-      } else if (localState.error[id].resp.message) {
+      } else if (get(localState, `error.${id}.resp.message`)) {
         message = localState.error[id].resp.message;
       } else {
         message = `${localState.error[id].resp.status}: ${localState.error[id].resp.statusText}`;

--- a/src/workflows/pyfr/common/steps/Simulation/View/index.js
+++ b/src/workflows/pyfr/common/steps/Simulation/View/index.js
@@ -29,7 +29,7 @@ const SimualtionView = React.createClass({
     view: React.PropTypes.string,
 
     onTerminateTaskflow: React.PropTypes.func,
-    onDeleteTaskflow: React.PropTypes.func,
+    onRerun: React.PropTypes.func,
     onVisualizeTaskflow: React.PropTypes.func,
     onTerminateInstance: React.PropTypes.func,
     onMount: React.PropTypes.func,
@@ -68,22 +68,15 @@ const SimualtionView = React.createClass({
     this.props.onTerminateTaskflow(this.props.taskflowId);
   },
 
-  deleteTaskflow() {
-    const simulationStep = {
-      id: this.props.simulation._id,
-      step: 'Simulation',
-      data: {
-        view: 'default',
-        metadata: {},
-      },
-    };
+  rerun() {
+    const stepData = { view: 'default', metadata: {} };
     const location = {
       pathname: this.props.location.pathname,
       query: { view: 'default' },
       state: this.props.location.state,
     };
 
-    this.props.onDeleteTaskflow(this.props.taskflowId, simulationStep, location);
+    this.props.onRerun(this.props.simulation._id, this.props.step, stepData, location);
   },
 
   render() {
@@ -152,7 +145,7 @@ export default connect(
     onVisualizeTaskflow: (sim, location) => {
       dispatch(SimActions.saveSimulation(sim, null, location));
     },
-    onDeleteTaskflow: (id, simulationStep, location) => dispatch(Actions.deleteTaskflow(id, simulationStep, location)),
+    onRerun: (id, stepName, stepData, location) => dispatch(SimActions.updateSimulationStep(id, stepName, stepData, location)),
     onTerminateTaskflow: (id) => dispatch(Actions.terminateTaskflow(id)),
     onTerminateInstance: (id) => dispatch(ClusterActions.terminateCluster(id)),
   })

--- a/src/workflows/pyfr/common/steps/Visualization/View/index.js
+++ b/src/workflows/pyfr/common/steps/Visualization/View/index.js
@@ -35,7 +35,7 @@ const VisualizationView = React.createClass({
     taskflowId: React.PropTypes.string,
     taskflow: React.PropTypes.object,
     cluster: React.PropTypes.object,
-    disabledButtons: React.PropTypes.bool,
+    disabledButtons: React.PropTypes.object,
     error: React.PropTypes.string,
   },
 
@@ -64,6 +64,7 @@ const VisualizationView = React.createClass({
       step: 'Visualization',
       data: {
         view: 'default',
+        metadata: {},
       },
     };
     const location = {

--- a/src/workflows/pyfr/common/steps/Visualization/View/index.js
+++ b/src/workflows/pyfr/common/steps/Visualization/View/index.js
@@ -28,7 +28,7 @@ const VisualizationView = React.createClass({
     view: React.PropTypes.string,
 
     onTerminateTaskflow: React.PropTypes.func,
-    onDeleteTaskflow: React.PropTypes.func,
+    onRerun: React.PropTypes.func,
     onVisualizeTaskflow: React.PropTypes.func,
     onTerminateInstance: React.PropTypes.func,
 
@@ -58,22 +58,15 @@ const VisualizationView = React.createClass({
     this.props.onTerminateTaskflow(this.props.taskflowId);
   },
 
-  deleteTaskflow() {
-    const simulationStep = {
-      id: this.props.simulation._id,
-      step: 'Visualization',
-      data: {
-        view: 'default',
-        metadata: {},
-      },
-    };
+  rerun() {
+    const stepData = { view: 'default', metadata: {} };
     const location = {
       pathname: this.props.location.pathname,
       query: { view: 'default' },
       state: this.props.location.state,
     };
 
-    this.props.onDeleteTaskflow(this.props.taskflowId, simulationStep, location);
+    this.props.onRerun(this.props.simulation._id, this.props.step, stepData, location);
   },
 
   buttonBarAction(action) {
@@ -158,7 +151,7 @@ export default connect(
   },
   () => ({
     onVisualizeTaskflow: (sim, location) => dispatch(SimActions.saveSimulation(sim, null, location)),
-    onDeleteTaskflow: (id, simulationStep, location) => dispatch(Actions.deleteTaskflow(id, simulationStep, location)),
+    onRerun: (id, stepName, stepData, location) => dispatch(SimActions.updateSimulationStep(id, stepName, stepData, location)),
     onTerminateTaskflow: (id) => dispatch(Actions.terminateTaskflow(id)),
     onTerminateInstance: (id) => dispatch(ClusterActions.terminateCluster(id)),
   })

--- a/src/workflows/pyfr/common/steps/Visualization/View/index.js
+++ b/src/workflows/pyfr/common/steps/Visualization/View/index.js
@@ -59,7 +59,13 @@ const VisualizationView = React.createClass({
   },
 
   rerun() {
-    const stepData = { view: 'default', metadata: {} };
+    const stepData = {
+      view: 'default',
+      metadata: Object.assign({}, this.props.simulation.steps.Visualization.metadata),
+    };
+    // we want to preserve some metadata objects
+    delete stepData.metadata.taskflowId;
+    delete stepData.metadata.sessionKey;
     const location = {
       pathname: this.props.location.pathname,
       query: { view: 'default' },

--- a/src/workflows/visualizer/components/steps/Visualization/View/index.js
+++ b/src/workflows/visualizer/components/steps/Visualization/View/index.js
@@ -28,7 +28,7 @@ const visualizationView = React.createClass({
     view: React.PropTypes.string,
 
     onTerminateTaskflow: React.PropTypes.func,
-    onDeleteTaskflow: React.PropTypes.func,
+    onRerun: React.PropTypes.func,
     onVisualizeTaskflow: React.PropTypes.func,
     onTerminateInstance: React.PropTypes.func,
 
@@ -66,22 +66,15 @@ const visualizationView = React.createClass({
     this.props.onTerminateTaskflow(this.props.taskflowId);
   },
 
-  deleteTaskflow() {
-    const simulationStep = {
-      id: this.props.simulation._id,
-      step: 'Visualization',
-      data: {
-        view: 'default',
-        metadata: {},
-      },
-    };
+  rerun() {
+    const stepData = { view: 'default', metadata: {} };
     const location = {
       pathname: this.props.location.pathname,
       query: { view: 'default' },
       state: this.props.location.state,
     };
 
-    this.props.onDeleteTaskflow(this.props.taskflowId, simulationStep, location);
+    this.props.onRerun(this.props.simulation._id, this.props.step, stepData, location);
   },
 
   render() {
@@ -152,7 +145,7 @@ export default connect(
   },
   () => ({
     onVisualizeTaskflow: (sim, location) => dispatch(SimActions.saveSimulation(sim, null, location)),
-    onDeleteTaskflow: (id, simulationStep, location) => dispatch(Actions.deleteTaskflow(id, simulationStep, location)),
+    onRerun: (id, stepName, stepData, location) => dispatch(SimActions.updateSimulationStep(id, stepName, stepData, location)),
     onTerminateTaskflow: (id) => dispatch(Actions.terminateTaskflow(id)),
     onTerminateInstance: (id) => dispatch(ClusterActions.terminateCluster(id)),
   })


### PR DESCRIPTION
When we click "rerun" we're deleting the current taskflow, in once case we were not sending an empty metadata object which would clear the old taskflowId. One take away is that we should try to minimize the amount of redundant code between workflows we have.

Fixed how the simulation object updates. Added some get()'s to some toaster conditionals which could throw errors themselves.