### PR TITLE
Hint how to login as hpccloud to have access to "demo_cluster"

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,11 @@ cd HPCCloud
 DEMO=1 vagrant up
 ```
 
-Once the vagrant provisioning process it complete your VM will up and running. You can access the HPCCloud application by visting [http://localhost:8888](http://localhost:8888)
+Once the vagrant provisioning process it complete your VM will up and running.
+
+You can then access the HPCCloud application by visiting [http://localhost:8888](http://localhost:8888) and logging in as user `hpccloud` with password `letmein`.
+
+(Note: you could also register as a new user, but then the preconfigurated "demo_cluster" wouldn't be available, which is provisioned within the Vagrant machine)
 
 ## Development
 


### PR DESCRIPTION
Had a hard time finding this out.

Btw, very cool project!

As a side note: I would expect the cluster configuration to be globally available to all users (or both: global clusters and pre-user clusters), so that the demo_cluster would be available to newley registered users aswell.