### PR TITLE
added missing 'copyFile' network function

### DIFF
--- a/src/network/remote/file.js
+++ b/src/network/remote/file.js
@@ -137,6 +137,10 @@ export default function ({ client, filterQuery, mustContain, busy, encodeQueryAs
       return missingKeys ? promise : busy(client._.put(`/file/${file._id}${encodeQueryAsString(params)}`));
     },
 
+    copyFile(fileId, itemId) {
+      return busy(client._.post(`/file/${fileId}/copy?itemId=${itemId}`));
+    },
+
     newFile(file) {
       const expected = ['parentType', 'parentId', 'name', 'size', 'mimeType', 'linkUrl'],
         params = filterQuery(file, ...expected),

--- a/src/workflows/pyfr/components/steps/Input/index.js
+++ b/src/workflows/pyfr/components/steps/Input/index.js
@@ -27,8 +27,9 @@ const SimputPanel = React.createClass({
     project: React.PropTypes.object,
     simulation: React.PropTypes.object,
     step: React.PropTypes.string,
-    updateSimulation: React.PropTypes.func,
     saveSimulation: React.PropTypes.func,
+    updateSimulation: React.PropTypes.func,
+    patchSimulation: React.PropTypes.func,
   },
 
   getDefaultProps() {
@@ -97,7 +98,7 @@ const SimputPanel = React.createClass({
           newSim.metadata.inputFolder.files.ini = _id;
           newSim.steps[this.props.step].metadata.model = JSON.stringify(jsonData);
           this.setState({ iniFile: _id });
-          dispatch(Actions.patchSimulation(newSim));
+          this.props.patchSimulation(newSim);
           // Update step metadata
           return client.updateSimulationStep(this.props.simulation._id, this.props.step, {
             metadata: { model: JSON.stringify(jsonData) },
@@ -139,7 +140,7 @@ const SimputPanel = React.createClass({
             }).then((simResp) => {
               var newSim = deepClone(this.props.simulation);
               newSim.steps[this.props.step].metadata.model = JSON.stringify(jsonData);
-              dispatch(Actions.patchSimulation(newSim));
+              this.props.patchSimulation(newSim);
             });
           } catch (e) {
             NetActions.errorNetworkCall('simput_parse', { message: `Error parsing input file:\n${e}\nLoading default values.` });
@@ -256,5 +257,6 @@ export default connect(
   () => ({
     saveSimulation: (simulation) => dispatch(Actions.saveSimulation(simulation)),
     updateSimulation: (simulation) => dispatch(Actions.updateSimulation(simulation)),
+    patchSimulation: (simulation) => dispatch(Actions.patchSimulation(simulation)),
   })
 )(SimputPanel);

--- a/src/workflows/pyfr/components/steps/Simulation/Start/index.js
+++ b/src/workflows/pyfr/components/steps/Simulation/Start/index.js
@@ -14,6 +14,7 @@ import getNetworkError  from '../../../../../../utils/getNetworkError';
 import { connect } from 'react-redux';
 import { dispatch } from '../../../../../../redux';
 import * as Actions    from '../../../../../../redux/actions/taskflows';
+import { patchSimulation } from '../../../../../../redux/actions/projects';
 import * as NetActions from '../../../../../../redux/actions/network';
 
 const SimulationStart = React.createClass({
@@ -32,6 +33,7 @@ const SimulationStart = React.createClass({
     clusters: React.PropTypes.object,
     onRun: React.PropTypes.func,
     onError: React.PropTypes.func,
+    patchSimulation: React.PropTypes.func,
   },
 
   getInitialState() {
@@ -50,13 +52,13 @@ const SimulationStart = React.createClass({
     if (!iniFile) {
       client.createItem(this.props.simulation.metadata.inputFolder._id, 'ini')
         .then(resp =>
-          client.copyFile(this.props.simulation.metadata.inputFolder.files.ini, resp.data._id)
+          client.copyFile(this.props.project.metadata.inputFolder.files.ini, resp.data._id)
         )
         .then(resp => {
           const newSim = deepClone(this.props.simulation);
           newSim.metadata.inputFolder.files.ini = resp.data._id;
           this.setState({ iniFile: resp.data._id });
-          dispatch(Actions.patchSimulation(newSim));
+          this.props.patchSimulation(newSim);
         })
         .catch(err => {
           console.log('Error copying ini file for simulation', err);
@@ -207,6 +209,7 @@ export default connect(
       onRun: (taskflowName, primaryJob, payload, simulationStep, location) =>
         dispatch(Actions.createTaskflow(taskflowName, primaryJob, payload, simulationStep, location)),
       onError: (message) => dispatch(NetActions.errorNetworkCall('create_taskflow', { data: { message } }, 'form')),
+      patchSimulation: (newSim) => dispatch(patchSimulation(newSim)),
     };
   }
 )(SimulationStart);


### PR DESCRIPTION
This is a hotfix, best way to test: 

- create new pyfr project with an ini file
- create new simulation, do not provide ini file
- open new simulation
- go directly to the 'simulation' step

There would be an error before, the network lib was missing the "copyFile" function