### PR TITLE
Fix master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
     - ln -s "${HOME}/build/Kitware/HPCCloud/server/pvwproxy" "${HOME}/build/girder/plugins/pvwproxy"
     # Install CMake
     - CACHE=$HOME/.cache CMAKE_VERSION=3.1.0 CMAKE_SHORT_VERSION=3.1 source $HOME/build/girder/scripts/install_cmake.sh
-    - nvm install 4.1
+    - nvm install 5.1
 
 install:
     - pip install -U -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
             - ubuntu-toolchain-r-test
         packages:
             - g++-4.8
+            - libgif-dev
 
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
     - "2.7"
@@ -6,7 +7,16 @@ python:
 node_js:
     - "4.1"
 
-sudo: false
+env:
+    - CXX=g++-4.8
+
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - g++-4.8
+
 notifications:
     email:
         recipients:


### PR DESCRIPTION
Wow, that was a bit of an odyssey :ocean: 

In summary:
- Bumped C++ compiler to support c++11, need by node-gyp
- Installed libgif-dev
- Bumped node to 5.1

I think this was broken by the docs, PR not sure how!/why!? 