### PR TITLE
Rename update method to prevent override

### DIFF
--- a/server/hpccloud/server/models/project.py
+++ b/server/hpccloud/server/models/project.py
@@ -102,7 +102,7 @@ class Project(AccessControlledModel):
 
         return project
 
-    def update(self, user, project, name=None, metadata=None, description=None):
+    def update_project(self, user, project, name=None, metadata=None, description=None):
         """
         Update an existing project, this involves update the data property.
         For now we will just do a dict update, in the future we might want

--- a/server/hpccloud/server/models/simulation.py
+++ b/server/hpccloud/server/models/simulation.py
@@ -149,8 +149,9 @@ class Simulation(AccessControlledModel):
         self.remove(simulation)
         self.model('folder').remove(simulation_folder)
 
-    def update(self, user, simulation, name, metadata=None, description=None,
-               active=None, disabled=None, status=None, steps=None):
+    def update_simulation(self, user, simulation, name, metadata=None,
+                          description=None, active=None, disabled=None,
+                          status=None, steps=None):
         """
         Update a simulation.
 

--- a/server/hpccloud/server/projects.py
+++ b/server/hpccloud/server/projects.py
@@ -86,8 +86,9 @@ class Projects(Resource):
         metadata = updates.get('metadata')
         description = updates.get('description')
 
-        return self._model.update(user, project, name=name, metadata=metadata,
-                                  description=description)
+        return self._model.update_project(user, project, name=name,
+                                          metadata=metadata,
+                                          description=description)
 
     @autoDescribeRoute(
         Description('Get all projects this user has access to project')

--- a/server/hpccloud/server/simulations.py
+++ b/server/hpccloud/server/simulations.py
@@ -119,10 +119,9 @@ class Simulations(Resource):
         metadata = updates.get('metadata')
         steps = updates.get('steps')
 
-        return self._model.update(user, simulation, name=name,
-                                  metadata=metadata, description=description,
-                                  active=active, disabled=disabled,
-                                  status=status, steps=steps)
+        return self._model.update_simulation(user, simulation, name,
+                                             metadata, description, active,
+                                             disabled,  status, steps)
 
     addModel('CloneParams', {
         'id': 'CloneParams',


### PR DESCRIPTION
The use of the update(...) signature was unintentional overriding the implementation provided by girder.models.model_base.Model. This cause problems when deleting groups which relies on this
base class implementation.