### PR TITLE
Use specified number of CPUs in the visualizer

### DIFF
--- a/server/taskflows/hpccloud/taskflow/paraview/visualizer.py
+++ b/server/taskflows/hpccloud/taskflow/paraview/visualizer.py
@@ -250,6 +250,12 @@ def submit_paraview_job(task, cluster, job, *args, **kwargs):
         paraview_install_dir = paraview_install_dir[0].value
         params['paraviewInstallDir'] = paraview_install_dir
 
+    if 'numberOfNodes' in kwargs:
+        params['numberOfNodes'] = kwargs['numberOfNodes']
+
+    if 'numberOfCoresPerNode' in kwargs:
+        params['numberOfCoresPerNode'] = kwargs['numberOfCoresPerNode']
+
     # Does the cluster have GPUs?
     params['gpu'] = has_gpus(cluster) or kwargs.get('numberOfGpusPerNode', 0) > 0
 


### PR DESCRIPTION
For slurm, the number of CPUs needs to be specified in order to use more
than one. Additionally, the [cumulus slurm template](https://github.com/Kitware/cumulus/blob/27a66935e4ae1bb77b5ee3398928739f147785e3/cumulus/templates/schedulers/slurm.sh#L11-L13) requires both the
number of nodes and the number of CPUs to be specified before it
will provide to slurm the --cpus-per-task flag.

Thus, we should ensure both the number of nodes and the number
of CPUs are specified.