### PR TITLE
Remove python2 from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ group: travis_lts
 
 language: python
 python:
-  - "2.7"
   - "3.6"
 
 node_js: 8


### PR DESCRIPTION
python2 is no longer supported by girder, so the travis-ci tests are
failing.

Remove python2 from testing.

We should eventually remove python2 support entirely, but that is being
tracked in #637.